### PR TITLE
Non-blocking clear() and reboot() method

### DIFF
--- a/WDTZero/src/WDTZero.h
+++ b/WDTZero/src/WDTZero.h
@@ -48,6 +48,7 @@
 # define WDT_SOFTCYCLE16M  0xF4BA    // EW on, @8192cycles/1024 x  2^7 = 1024S    "      111 1 -> 17  minutes to be precise ...
 
 
+void WDT_ForceShutdown(void);   // Global Method for immediate shutdown
 void WDT_Handler(void);         // ISR HANDLER FOR WDT EW INTERRUPT
 extern int WDTZeroCounter;      // SOFT COUNTER FOR EXTENDING WDT TIME VIA EW INTERRUPT
 
@@ -56,6 +57,7 @@ class WDTZero
   public:
     WDTZero();
     void clear();
+    void reboot();
     void setup(unsigned int wdtzerosetup);  
     void attachShutdown(voidFuncPtr callback);
     void detachShutdown();


### PR DESCRIPTION
Hi,

While researching for a watchdog implementation for my MKR Zero I've found your library. Great work! I've also found this post: https://hackaday.io/project/20647-mightywatt-r3-70w-electronic-load-for-arduino/log/56143-found-and-fixed-a-bug-in-sketch-for-arduino-zero

I've implemented this non-blocking clear of the watch dog.

In addition I'm in need for a `reboot()` (software reset) method. 
So I moved the reset you do when the Software EWT hits to a separate method `WDT_ForceShutdown` which gets called now from the original spot as well as from the new `reboot` method.

Do you see any issues?

Soko

